### PR TITLE
UX: update group selector modal window height

### DIFF
--- a/lib/presentation/pages/schedule/widgets/schedule_settings_modal.dart
+++ b/lib/presentation/pages/schedule/widgets/schedule_settings_modal.dart
@@ -93,7 +93,7 @@ class ScheduleSettingsModal extends StatelessWidget {
           ),
         ),
       ),
-      height: MediaQuery.of(context).size.height * 0.85,
+      height: MediaQuery.of(context).size.height * 0.95,
       decoration: BoxDecoration(
         gradient: LinearGradient(
           colors: [


### PR DESCRIPTION
Высота модального окна выбора группы увеличена с 85% до 95%, т.к. на маленьких устройствах клавиатура может перекрывать inputbox.