### PR TITLE
FEATURE: schedule from cache indication

### DIFF
--- a/lib/presentation/pages/schedule/schedule_screen.dart
+++ b/lib/presentation/pages/schedule/schedule_screen.dart
@@ -46,7 +46,23 @@ class _ScheduleScreenState extends State<ScheduleScreen> {
                 style: DarkTextTheme.buttonL,
               ),
               Row(
+                mainAxisSize: MainAxisSize.min,
                 children: [
+                  if (!schedule.isRemote)
+                    Container(
+                      alignment: Alignment.topRight,
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 12),
+                        alignment: Alignment.center,
+                        decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(100),
+                            color: DarkThemeColors.colorful06),
+                        height: 24,
+                        child: Text('кэш',
+                            style: DarkTextTheme.chip
+                                .copyWith(color: DarkThemeColors.background03)),
+                      ),
+                    ),
                   RawMaterialButton(
                     onPressed: () {
                       context.read<ScheduleBloc>().add(ScheduleUpdateEvent(

--- a/lib/presentation/pages/schedule/schedule_screen.dart
+++ b/lib/presentation/pages/schedule/schedule_screen.dart
@@ -30,13 +30,13 @@ class _ScheduleScreenState extends State<ScheduleScreen> {
     super.initState();
   }
 
-  Widget _buildGroupButton(String group, String activeGroup, bool isActive,
-      [Schedule? schedule]) {
+  Widget _buildGroupButton(
+      String group, String activeGroup, bool isActive, Schedule schedule) {
     if (isActive) {
       return Padding(
-        padding: EdgeInsets.only(bottom: 10),
+        padding: const EdgeInsets.only(bottom: 10),
         child: Container(
-          padding: EdgeInsets.only(left: 10),
+          padding: const EdgeInsets.only(left: 10),
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.center,
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -53,10 +53,10 @@ class _ScheduleScreenState extends State<ScheduleScreen> {
                           group: group, activeGroup: activeGroup));
                     },
                     child: Icon(Icons.refresh_rounded,
-                        color: schedule!.isRemote
+                        color: schedule.isRemote
                             ? DarkThemeColors.colorful05
                             : DarkThemeColors.colorful06),
-                    shape: CircleBorder(),
+                    shape: const CircleBorder(),
                     constraints:
                         const BoxConstraints(minWidth: 36.0, minHeight: 36.0),
                   ),
@@ -114,7 +114,7 @@ class _ScheduleScreenState extends State<ScheduleScreen> {
                   RawMaterialButton(
                     onPressed: () {
                       context.read<ScheduleBloc>().add(ScheduleDeleteEvent(
-                          group: group, schedule: schedule!));
+                          group: group, schedule: schedule));
                     },
                     child: const Icon(Icons.delete_rounded),
                     shape: CircleBorder(),

--- a/lib/presentation/pages/schedule/schedule_screen.dart
+++ b/lib/presentation/pages/schedule/schedule_screen.dart
@@ -49,20 +49,9 @@ class _ScheduleScreenState extends State<ScheduleScreen> {
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   if (!schedule.isRemote)
-                    Container(
-                      alignment: Alignment.topRight,
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(horizontal: 12),
-                        alignment: Alignment.center,
-                        decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(100),
-                            color: DarkThemeColors.colorful06),
-                        height: 24,
-                        child: Text('кэш',
-                            style: DarkTextTheme.chip
-                                .copyWith(color: DarkThemeColors.background03)),
-                      ),
-                    ),
+                    Text('кэш',
+                        style: DarkTextTheme.buttonS
+                            .copyWith(color: DarkThemeColors.colorful06)),
                   RawMaterialButton(
                     onPressed: () {
                       context.read<ScheduleBloc>().add(ScheduleUpdateEvent(
@@ -93,9 +82,9 @@ class _ScheduleScreenState extends State<ScheduleScreen> {
       );
     } else {
       return Padding(
-        padding: EdgeInsets.only(bottom: 10),
+        padding: const EdgeInsets.only(bottom: 10),
         child: Container(
-          padding: EdgeInsets.only(left: 10),
+          padding: const EdgeInsets.only(left: 10),
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.center,
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -113,7 +102,7 @@ class _ScheduleScreenState extends State<ScheduleScreen> {
                           .add(ScheduleSetActiveGroupEvent(group));
                     },
                     child: const Icon(Icons.check_rounded),
-                    shape: CircleBorder(),
+                    shape: const CircleBorder(),
                     constraints:
                         const BoxConstraints(minWidth: 36.0, minHeight: 36.0),
                   ),
@@ -123,7 +112,7 @@ class _ScheduleScreenState extends State<ScheduleScreen> {
                           group: group, activeGroup: activeGroup));
                     },
                     child: const Icon(Icons.refresh_rounded),
-                    shape: CircleBorder(),
+                    shape: const CircleBorder(),
                     constraints:
                         const BoxConstraints(minWidth: 36.0, minHeight: 36.0),
                   ),
@@ -133,7 +122,7 @@ class _ScheduleScreenState extends State<ScheduleScreen> {
                           group: group, schedule: schedule));
                     },
                     child: const Icon(Icons.delete_rounded),
-                    shape: CircleBorder(),
+                    shape: const CircleBorder(),
                     constraints:
                         const BoxConstraints(minWidth: 36.0, minHeight: 36.0),
                   ),


### PR DESCRIPTION
### Второй PR, связанный с #59 

После #74 надо было исправить параметр `schedule` метода `_buildGroupButton` в `lib/presentation/pages/schedule/schedule_screen.dart`, что собственно и [было сделано](https://github.com/Ninja-Official/rtu-mirea-mobile/commit/0540a8e2afa10d62c549d86e8679a003e88e808b) в первую очередь, а также задача не закрылась этим PR так как

> нужно дополнительно какое-то сообщение пользователю

Дополнительное сообщение сделано. Я немного поэксперементировал с интерфейсом и мне нравится 2 следующих варианта (первое - обычное состояние, когда есть доступ к интернету):

![All-Screenshots](https://user-images.githubusercontent.com/37776977/132134639-83347f71-0c4e-4b2d-b608-07bce579ee97.png)

Мне лично больше нравится второй вариант - он [реализован](https://github.com/Ninja-Official/rtu-mirea-mobile/commit/21412c2f7e1b815087ad57e9a7c10b1e8b699150) в PR, здесь я использую тот же виджет, что используется в расписании для отображения типа расписания, только используется общий жёлтый цвет, а цвет текста заменён на цвет фона (белый текст почти не виден). Также как вариант, можно сделать текст большими буквами, можно сдвинуть этот закруглённый контейнер к имени группы слева, а не к кнопке (хотя по моему мнению, это выглядит хуже). **В общем жду одобрение/отказ/корректирование идеи**, если всё ок и выглядит как надо, сделаю ещё небольшой коммит с рефакторингом этой части перед слиянием.