### PR TITLE
FIX: schedule loading from internet on start

### DIFF
--- a/lib/domain/repositories/schedule_repository.dart
+++ b/lib/domain/repositories/schedule_repository.dart
@@ -4,7 +4,7 @@ import 'package:rtu_mirea_app/domain/entities/schedule.dart';
 import 'package:rtu_mirea_app/domain/entities/schedule_settings.dart';
 
 abstract class ScheduleRepository {
-  Future<Either<Failure, Schedule>> getSchedule(String group);
+  Future<Either<Failure, Schedule>> getSchedule(String group, bool fromRemote);
   Future<Either<Failure, List<Schedule>>> getDownloadedSchedules();
   Future<Either<Failure, List<String>>> getAllGroups();
   Future<Either<Failure, String>> getActiveGroup();

--- a/lib/domain/usecases/get_schedule.dart
+++ b/lib/domain/usecases/get_schedule.dart
@@ -12,15 +12,17 @@ class GetSchedule extends UseCase<Schedule, GetScheduleParams> {
 
   @override
   Future<Either<Failure, Schedule>> call(GetScheduleParams params) async {
-    return await scheduleRepository.getSchedule(params.group);
+    return await scheduleRepository.getSchedule(
+        params.group, params.fromRemote);
   }
 }
 
 class GetScheduleParams extends Equatable {
   final String group;
+  final bool fromRemote;
 
-  GetScheduleParams({required this.group});
+  GetScheduleParams({required this.group, required this.fromRemote});
 
   @override
-  List<Object?> get props => [group];
+  List<Object?> get props => [group, fromRemote];
 }

--- a/lib/presentation/bloc/schedule_bloc/schedule_state.dart
+++ b/lib/presentation/bloc/schedule_bloc/schedule_state.dart
@@ -33,25 +33,18 @@ class ScheduleLoaded extends ScheduleState {
   final Schedule schedule;
   final String activeGroup;
   final List<String> downloadedScheduleGroups;
-  final List<String> groups;
   final ScheduleSettings scheduleSettings;
 
   ScheduleLoaded({
     required this.schedule,
     required this.activeGroup,
     required this.downloadedScheduleGroups,
-    required this.groups,
     required this.scheduleSettings,
   });
 
   @override
-  List<Object> get props => [
-        schedule,
-        activeGroup,
-        downloadedScheduleGroups,
-        groups,
-        scheduleSettings
-      ];
+  List<Object> get props =>
+      [schedule, activeGroup, downloadedScheduleGroups, scheduleSettings];
 }
 
 class ScheduleLoadError extends ScheduleState {

--- a/lib/presentation/pages/schedule/schedule_screen.dart
+++ b/lib/presentation/pages/schedule/schedule_screen.dart
@@ -242,8 +242,8 @@ class _ScheduleScreenState extends State<ScheduleScreen> {
                                   context: context,
                                   isScrollControlled: true,
                                   backgroundColor: Colors.transparent,
-                                  builder: (context) => ScheduleSettingsModal(
-                                      groups: state.groups, isFirstRun: false),
+                                  builder: (context) =>
+                                      ScheduleSettingsModal(isFirstRun: false),
                                 ).whenComplete(() {
                                   this._modalShown = false;
                                 });
@@ -325,8 +325,8 @@ class _ScheduleScreenState extends State<ScheduleScreen> {
                         context: context,
                         isScrollControlled: true,
                         backgroundColor: Colors.transparent,
-                        builder: (context) => ScheduleSettingsModal(
-                            groups: state.groups, isFirstRun: true),
+                        builder: (context) =>
+                            ScheduleSettingsModal(isFirstRun: true),
                       ).whenComplete(() {
                         this._modalShown = false;
                       });

--- a/lib/presentation/pages/schedule/widgets/autocomplete_group_selector.dart
+++ b/lib/presentation/pages/schedule/widgets/autocomplete_group_selector.dart
@@ -28,10 +28,8 @@ class GroupTextFormatter extends TextInputFormatter {
 }
 
 class AutocompleteGroupSelector extends StatefulWidget {
-  AutocompleteGroupSelector({Key? key, required this.groupsList})
-      : super(key: key);
+  AutocompleteGroupSelector({Key? key}) : super(key: key);
 
-  final List<String> groupsList;
   @override
   _AutocompleteGroupSelectorState createState() =>
       _AutocompleteGroupSelectorState();
@@ -56,60 +54,61 @@ class _AutocompleteGroupSelectorState extends State<AutocompleteGroupSelector> {
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<ScheduleBloc, ScheduleState>(
-        buildWhen: (prevState, currentState) => prevState != currentState,
-        builder: (context, state) {
-          return TypeAheadField(
-            hideOnError: false,
-            textFieldConfiguration: TextFieldConfiguration(
-              focusNode: FocusNode(),
-              controller: _inputController,
-              autofocus: false,
-              style: DarkTextTheme.titleM,
-              keyboardType: _keyboardType,
-              autocorrect: false,
-              textCapitalization: TextCapitalization.characters,
-              inputFormatters: [
-                GroupTextFormatter(),
-              ],
-              decoration: InputDecoration(
-                errorText: state is ScheduleGroupNotFound
-                    ? 'заданная группа не найдена'
-                    : null,
-                hintText: 'АБВГ-12-34',
-                hintStyle: DarkTextTheme.titleM
-                    .copyWith(color: DarkThemeColors.deactive),
-                focusedBorder: UnderlineInputBorder(
-                  borderSide: BorderSide(color: DarkThemeColors.colorful05),
-                ),
+      buildWhen: (prevState, currentState) => prevState != currentState,
+      builder: (context, state) {
+        return TypeAheadField(
+          hideOnError: false,
+          textFieldConfiguration: TextFieldConfiguration(
+            focusNode: FocusNode(),
+            controller: _inputController,
+            autofocus: false,
+            style: DarkTextTheme.titleM,
+            keyboardType: _keyboardType,
+            autocorrect: false,
+            textCapitalization: TextCapitalization.characters,
+            inputFormatters: [
+              GroupTextFormatter(),
+            ],
+            decoration: InputDecoration(
+              errorText: state is ScheduleGroupNotFound
+                  ? 'заданная группа не найдена'
+                  : null,
+              hintText: 'АБВГ-12-34',
+              hintStyle: DarkTextTheme.titleM
+                  .copyWith(color: DarkThemeColors.deactive),
+              focusedBorder: UnderlineInputBorder(
+                borderSide: BorderSide(color: DarkThemeColors.colorful05),
               ),
             ),
-            itemBuilder: (context, suggestion) => Container(
-              color: DarkThemeColors.background03,
-              child: Padding(
-                padding: EdgeInsets.all(4.0),
-                child: Text(suggestion.toString()),
-              ),
+          ),
+          itemBuilder: (context, suggestion) => Container(
+            color: DarkThemeColors.background03,
+            child: Padding(
+              padding: EdgeInsets.all(4.0),
+              child: Text(suggestion.toString()),
             ),
-            noItemsFoundBuilder: (context) => Container(
-              alignment: Alignment.center,
-              color: DarkThemeColors.background03,
-              child: Text('Группы не найдены', style: DarkTextTheme.titleM),
-            ),
-            suggestionsCallback: (search) async {
-              context.read<ScheduleBloc>().add(
-                  ScheduleUpdateGroupSuggestionEvent(
-                      suggestion: search.toUpperCase()));
-              return widget.groupsList
-                  .where((group) =>
-                      group.toUpperCase().contains(search.toUpperCase()))
-                  .toList();
-            },
-            onSuggestionSelected: (String suggestion) {
-              _inputController.text = suggestion;
-              context.read<ScheduleBloc>().add(
-                  ScheduleUpdateGroupSuggestionEvent(suggestion: suggestion));
-            },
-          );
-        });
+          ),
+          noItemsFoundBuilder: (context) => Container(
+            alignment: Alignment.center,
+            color: DarkThemeColors.background03,
+            child: Text('Группы не найдены', style: DarkTextTheme.titleM),
+          ),
+          suggestionsCallback: (search) async {
+            context.read<ScheduleBloc>().add(ScheduleUpdateGroupSuggestionEvent(
+                suggestion: search.toUpperCase()));
+            return ScheduleBloc.groupsList
+                .where((group) =>
+                    group.toUpperCase().contains(search.toUpperCase()))
+                .toList();
+          },
+          keepSuggestionsOnSuggestionSelected: true,
+          onSuggestionSelected: (String suggestion) {
+            _inputController.text = suggestion;
+            context.read<ScheduleBloc>().add(
+                ScheduleUpdateGroupSuggestionEvent(suggestion: suggestion));
+          },
+        );
+      },
+    );
   }
 }

--- a/lib/presentation/pages/schedule/widgets/schedule_settings_modal.dart
+++ b/lib/presentation/pages/schedule/widgets/schedule_settings_modal.dart
@@ -7,11 +7,9 @@ import 'package:rtu_mirea_app/presentation/theme.dart';
 import 'package:rtu_mirea_app/presentation/widgets/keyboard_positioned.dart';
 
 class ScheduleSettingsModal extends StatelessWidget {
-  const ScheduleSettingsModal(
-      {Key? key, required this.groups, required this.isFirstRun})
+  const ScheduleSettingsModal({Key? key, required this.isFirstRun})
       : super(key: key);
 
-  final List<String> groups;
   final bool isFirstRun;
 
   @override
@@ -57,13 +55,11 @@ class ScheduleSettingsModal extends StatelessWidget {
                   ],
                 ),
                 SizedBox(height: 8),
-                AutocompleteGroupSelector(
-                  groupsList: groups,
-                ),
+                AutocompleteGroupSelector(),
                 SizedBox(height: 32),
                 ConstrainedBox(
-                  constraints:
-                      BoxConstraints.tightFor(width: double.infinity, height: 48),
+                  constraints: BoxConstraints.tightFor(
+                      width: double.infinity, height: 48),
                   child: ElevatedButton(
                     style: ButtonStyle(
                       backgroundColor:


### PR DESCRIPTION
Исправлено #84. Теперь расписание по умолчанию загружается мгновенно из кэша, а обновляется в процессе уже потом. В репозиторий методу `getSchedule` был добавлен параметр `fromRemote`, который определяет, загружать ли расписание из удалённого репозитория или локального.

Чтобы не замедлять запуск, список всех групп загружается асинхронно при старте и теперь представляет из себя статическое публичное поле в ScheduleBloc, а не поле в состоянии ScheduleLoaded. Таким образом, не нужно будет обновлять состояние после загрузки расписания.

Поле `groups` убрано из состояния ScheduleLoaded.