### PR TITLE
FIX: build schedule in next week and from cache

### DIFF
--- a/lib/common/calendar.dart
+++ b/lib/common/calendar.dart
@@ -13,15 +13,7 @@ abstract class Calendar {
   static int getCurrentWeek(
       {DateTime? mCurrentDate, final Clock clock = const Clock()}) {
     DateTime currentDate = mCurrentDate ?? clock.now();
-    int currentYear = currentDate.year;
-
-    DateTime startDate;
-
-    if (currentDate.month >= DateTime.september) {
-      startDate = DateTime.utc(currentYear, 9, 1);
-    } else {
-      startDate = DateTime.utc(currentYear, 2, 8);
-    }
+    DateTime startDate = getSemesterStart();
 
     int week = 1;
     int prevWeekday = startDate.weekday;

--- a/lib/common/calendar.dart
+++ b/lib/common/calendar.dart
@@ -13,7 +13,7 @@ abstract class Calendar {
   static int getCurrentWeek(
       {DateTime? mCurrentDate, final Clock clock = const Clock()}) {
     DateTime currentDate = mCurrentDate ?? clock.now();
-    DateTime startDate = getSemesterStart();
+    DateTime startDate = getSemesterStart(mCurrentDate: currentDate);
 
     int week = 1;
     int prevWeekday = startDate.weekday;

--- a/lib/presentation/bloc/schedule_bloc/schedule_event.dart
+++ b/lib/presentation/bloc/schedule_bloc/schedule_event.dart
@@ -26,8 +26,8 @@ class ScheduleUpdateGroupSuggestionEvent extends ScheduleEvent {
 class ScheduleGroupsLoadEvent extends ScheduleEvent {}
 
 /// The event should be called to set the active group for which
-/// the schedule will be taken. The group name is the [groupSuggestion]
-/// field in [ScheduleBloc]. [groupSuggestion] should be set every
+/// the schedule will be taken. The group name is the [_groupSuggestion]
+/// field in [ScheduleBloc]. [_groupSuggestion] should be set every
 /// time the input is updated using the event
 /// [ScheduleUpdateGroupSuggestionEvent].
 class ScheduleSetActiveGroupEvent extends ScheduleEvent {

--- a/lib/presentation/pages/schedule/schedule_screen.dart
+++ b/lib/presentation/pages/schedule/schedule_screen.dart
@@ -309,8 +309,10 @@ class _ScheduleScreenState extends State<ScheduleScreen> {
         body: SafeArea(
           child: BlocBuilder<ScheduleBloc, ScheduleState>(
             buildWhen: (prevState, currentState) {
-              if (prevState is ScheduleLoaded && currentState is ScheduleLoaded)
+              if (prevState is ScheduleLoaded &&
+                  currentState is ScheduleLoaded) {
                 return prevState != currentState;
+              }
               return true;
             },
             builder: (context, state) {

--- a/lib/presentation/pages/schedule/widgets/schedule_page_view.dart
+++ b/lib/presentation/pages/schedule/widgets/schedule_page_view.dart
@@ -34,8 +34,6 @@ class _SchedulePageViewState extends State<SchedulePageView> {
   final DateTime _lastCalendarDay =
       DateTime.utc(2021, 12, 19); // TODO: create method for it
 
-  late List<List<Lesson>> _allLessonsInWeek;
-
   @override
   void initState() {
     super.initState();
@@ -45,7 +43,6 @@ class _SchedulePageViewState extends State<SchedulePageView> {
     _controller = PageController(initialPage: _selectedPage);
     _selectedDay = DateTime.now();
     _selectedWeek = Calendar.getCurrentWeek();
-    _allLessonsInWeek = _getLessonsByWeek(_selectedWeek, widget.schedule);
     _calendarFormat = CalendarFormat.values[
         (BlocProvider.of<ScheduleBloc>(context).state as ScheduleLoaded)
             .scheduleSettings
@@ -133,16 +130,15 @@ class _SchedulePageViewState extends State<SchedulePageView> {
     return lessons;
   }
 
-  Widget _buildPageViewContent(BuildContext context, int index) {
+  Widget _buildPageViewContent(BuildContext context, int index, int week) {
     if (index == 6) {
       return _buildEmptyLessons();
     } else {
-      var lessons = _allLessonsInWeek[index];
+      var lessons = _getLessonsByWeek(week, widget.schedule)[index];
 
       if (lessons.length == 0) return _buildEmptyLessons();
 
-      final state =
-          (BlocProvider.of<ScheduleBloc>(context).state as ScheduleLoaded);
+      final state = context.read<ScheduleBloc>().state as ScheduleLoaded;
       final ScheduleSettings settings = state.scheduleSettings;
       if (settings.showEmptyLessons) {
         lessons = _getLessonsWithEmpty(lessons, state.activeGroup);
@@ -174,13 +170,6 @@ class _SchedulePageViewState extends State<SchedulePageView> {
           },
         ),
       );
-    }
-  }
-
-  void _setLessonsByWeek(int week) {
-    if (week != _selectedWeek) {
-      _selectedWeek = week;
-      _allLessonsInWeek = _getLessonsByWeek(week, widget.schedule);
     }
   }
 
@@ -270,12 +259,11 @@ class _SchedulePageViewState extends State<SchedulePageView> {
                   Calendar.getCurrentWeek(mCurrentDate: selectedDay);
               // Call `setState()` when updating the selected day
               setState(() {
-                _setLessonsByWeek(currentNewWeek);
+                _selectedWeek = currentNewWeek;
                 _selectedPage =
                     selectedDay.difference(_firstCalendarDay).inDays;
                 _selectedDay = selectedDay;
                 _focusedDay = focusedDay;
-                _selectedWeek = currentNewWeek;
                 _controller.jumpToPage(_selectedPage);
               });
             }
@@ -302,6 +290,8 @@ class _SchedulePageViewState extends State<SchedulePageView> {
               _focusedDay = currentDate;
               _selectedDay = currentDate;
               _selectedPage = _selectedDay.difference(_firstCalendarDay).inDays;
+              _selectedWeek =
+                  Calendar.getCurrentWeek(mCurrentDate: _selectedDay);
               _controller.jumpToPage(_selectedPage);
             });
           },
@@ -327,15 +317,19 @@ class _SchedulePageViewState extends State<SchedulePageView> {
                         ),
                         onPressed: () {
                           setState(() {
-                            _selectedWeek = i;
-                            _selectedDay =
-                                Calendar.getDaysInWeek(_selectedWeek)[0];
-                            _focusedDay = _selectedDay;
+                            if (i == 1) {
+                              _selectedDay = Calendar.getDaysInWeek(
+                                  i)[Calendar.getSemesterStart().weekday - 1];
+                            } else {
+                              _selectedDay = Calendar.getDaysInWeek(i)[0];
+                            }
+
+                            _selectedDay = _selectedDay;
                             _selectedPage = _selectedDay
                                 .difference(_firstCalendarDay)
                                 .inDays;
-                            _allLessonsInWeek = _getLessonsByWeek(
-                                _selectedWeek, widget.schedule);
+                            _selectedWeek = i;
+                            _focusedDay = _selectedDay;
                             _controller.jumpToPage(_selectedPage);
                           });
                         },
@@ -358,14 +352,17 @@ class _SchedulePageViewState extends State<SchedulePageView> {
               physics: ClampingScrollPhysics(),
               onPageChanged: (value) {
                 setState(() {
-                  if (value > _selectedPage)
-                    _selectedDay = _selectedDay.add(Duration(days: 1));
-                  else if (value < _selectedPage)
-                    _selectedDay = _selectedDay.subtract(Duration(days: 1));
-                  final int currentNewWeek =
-                      Calendar.getCurrentWeek(mCurrentDate: _selectedDay);
+                  // if the pages are moved by swipes
+                  if ((value - _selectedPage).abs() == 1) {
+                    if (value > _selectedPage)
+                      _selectedDay = _selectedDay.add(Duration(days: 1));
+                    else if (value < _selectedPage)
+                      _selectedDay = _selectedDay.subtract(Duration(days: 1));
+                    final int currentNewWeek =
+                        Calendar.getCurrentWeek(mCurrentDate: _selectedDay);
+                    _selectedWeek = currentNewWeek;
+                  }
                   _focusedDay = _selectedDay;
-                  _setLessonsByWeek(currentNewWeek);
                   _selectedPage = value;
                 });
               },
@@ -379,7 +376,7 @@ class _SchedulePageViewState extends State<SchedulePageView> {
                     week >= 1 && week <= Calendar.kMaxWeekInSemester
                         ? lessonDay.weekday - 1
                         : 6;
-                return _buildPageViewContent(context, lessonIndex);
+                return _buildPageViewContent(context, lessonIndex, week);
               }),
         )
       ],

--- a/lib/service_locator.dart
+++ b/lib/service_locator.dart
@@ -125,7 +125,8 @@ Future<void> setup() async {
   // Common / Core
 
   // External Dependency
-  getIt.registerLazySingleton(() => Dio());
+  getIt.registerLazySingleton(
+      () => Dio(BaseOptions(connectTimeout: 3000, receiveTimeout: 3000)));
   final sharedPreferences = await SharedPreferences.getInstance();
   getIt.registerLazySingleton(() => sharedPreferences);
   getIt.registerLazySingleton(() => InternetConnectionChecker());


### PR DESCRIPTION
1. Если расписание загружено из кэша, но было обновлено в процессе, то состояние расписания (isRemote) теперь тоже обновляется.
2. Список предметов теперь получается не для целой недели, а для конкретного дня. То есть теперь расписание резко не меняется при смене недели, как это показано на видео ниже.

https://user-images.githubusercontent.com/51058739/132543110-d40f25bf-9e01-470e-a89a-3c1735175a36.MP4

