### PR TITLE
FIX: add displaying evening lessons

### DIFF
--- a/lib/presentation/bloc/schedule_bloc/schedule_bloc.dart
+++ b/lib/presentation/bloc/schedule_bloc/schedule_bloc.dart
@@ -244,7 +244,9 @@ class ScheduleBloc extends Bloc<ScheduleEvent, ScheduleState> {
         "12:40": 3,
         "14:20": 4,
         "16:20": 5,
-        "18:00": 6
+        "18:00": 6,
+        "18:30": 7,
+        "20:10": 8
       };
 
   static Map<String, int> get universityTimesEnd => const {
@@ -253,7 +255,9 @@ class ScheduleBloc extends Bloc<ScheduleEvent, ScheduleState> {
         "14:10": 3,
         "15:50": 4,
         "17:50": 5,
-        "19:30": 6
+        "19:30": 6,
+        "20:00": 7,
+        "21:40": 8
       };
 
   static bool isCollegeGroup(String group) {

--- a/lib/presentation/pages/schedule/widgets/schedule_page_view.dart
+++ b/lib/presentation/pages/schedule/widgets/schedule_page_view.dart
@@ -112,17 +112,20 @@ class _SchedulePageViewState extends State<SchedulePageView> {
           }
         }
         if (notEmpty == false) {
-          formattedLessons.add(
-            Lesson(
-              name: '',
-              rooms: [],
-              timeStart: key,
-              timeEnd: ScheduleBloc.universityTimesEnd.keys.toList()[value - 1],
-              weeks: [],
-              types: '',
-              teachers: [],
-            ),
-          );
+          if (value != 7 && value != 8) {
+            formattedLessons.add(
+              Lesson(
+                name: '',
+                rooms: [],
+                timeStart: key,
+                timeEnd:
+                    ScheduleBloc.universityTimesEnd.keys.toList()[value - 1],
+                weeks: [],
+                types: '',
+                teachers: [],
+              ),
+            );
+          }
         }
       });
     }


### PR DESCRIPTION
Хотфикс, который исправляет баг для магистратуры. Вечерние пары не отображались при включенном отображении пустых пар.