### PR TITLE
FIX: Home widgets logic based on random

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,7 @@ jobs:
         java-version: '12.x'
     - uses: subosito/flutter-action@v1
       with:
+        flutter-version: '2.5.3'
         channel: 'stable' # or: 'beta', 'dev' or 'master'
     - run: flutter pub get
     - run: flutter test ./test/mirea_test.dart

--- a/android/app/src/main/kotlin/ninja/mirea/mireaapp/HomeWidgerProvider.kt
+++ b/android/app/src/main/kotlin/ninja/mirea/mireaapp/HomeWidgerProvider.kt
@@ -67,6 +67,7 @@ class HomeWidgetProvider : AbstractHomeWidgetProvider() {
                     MainActivity::class.java
                 )
                 setOnClickPendingIntent(R.id.widget_container, pendingIntent)
+                setOnClickPendingIntent(R.id.widget_placeHolder, pendingIntent)
 //                setOnClickPendingIntent(R.id.lvList, pendingIntent)
 
 
@@ -140,6 +141,9 @@ class HomeWidgetProvider : AbstractHomeWidgetProvider() {
         adapter.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
         adapter.putExtra("schedule", schedule)
         adapter.putExtra("week", week)
+        val random = Random()
+        adapter.type = (random.nextInt(2281337)).toString()
+
         rv.setRemoteAdapter(R.id.lvList, adapter)
     }
 }

--- a/android/app/src/main/kotlin/ninja/mirea/mireaapp/widget_channel/HomeFactory2.kt
+++ b/android/app/src/main/kotlin/ninja/mirea/mireaapp/widget_channel/HomeFactory2.kt
@@ -34,6 +34,7 @@ class HomeFactory2 internal constructor(val context: Context, val intent: Intent
         return RemoteViews(context.packageName, R.layout.timetable_item)
     }
 
+    private  val maxLen = 50;
     override fun getViewAt(position: Int): RemoteViews {
         val rView = RemoteViews(
             context.packageName,
@@ -41,10 +42,10 @@ class HomeFactory2 internal constructor(val context: Context, val intent: Intent
         )
         if (data[position].name.isNotEmpty()) {
             var main = data[position].name
-            if (main.length > 50)
-                main = main.substring(0, 47) + "..."
+            if (main.length > maxLen)
+                main = main.substring(0, maxLen-3) + "..."
             if (data[position].rooms.isNotEmpty()) {
-                main += if (main.length >= 50)
+                main += if (main.length >= maxLen)
                     " " + data[position].rooms[0]
                 else
                     ", " + data[position].rooms[0]
@@ -100,6 +101,9 @@ class HomeFactory2 internal constructor(val context: Context, val intent: Intent
         val scheduleData =
             intent.getStringExtra("schedule")
         val weekData = intent.getStringExtra("week")
+
+        print(scheduleData);
+        print(weekData);
 
         if (scheduleData != null && scheduleData.isNotEmpty() && weekData != null && weekData.isNotEmpty()) {
             val scheduleModel = Json.decodeFromString(ScheduleModel.serializer(), scheduleData)

--- a/android/app/src/main/kotlin/ninja/mirea/mireaapp/widget_channel/HomeFactory2.kt
+++ b/android/app/src/main/kotlin/ninja/mirea/mireaapp/widget_channel/HomeFactory2.kt
@@ -102,8 +102,8 @@ class HomeFactory2 internal constructor(val context: Context, val intent: Intent
             intent.getStringExtra("schedule")
         val weekData = intent.getStringExtra("week")
 
-        print(scheduleData);
-        print(weekData);
+//        print(scheduleData);
+//        print(weekData);
 
         if (scheduleData != null && scheduleData.isNotEmpty() && weekData != null && weekData.isNotEmpty()) {
             val scheduleModel = Json.decodeFromString(ScheduleModel.serializer(), scheduleData)

--- a/android/app/src/main/kotlin/ninja/mirea/mireaapp/widget_channel/UpdateWidgetService.kt
+++ b/android/app/src/main/kotlin/ninja/mirea/mireaapp/widget_channel/UpdateWidgetService.kt
@@ -7,6 +7,7 @@ import android.widget.RemoteViewsService
 class UpdateWidgetService : RemoteViewsService() {
     override
     fun onGetViewFactory(intent: Intent?): RemoteViewsFactory {
+//        val a = intent?.getStringExtra("schedule");
         return HomeFactory2(applicationContext, intent!!)
     }
 }

--- a/android/app/src/main/res/xml/timetable_widget.xml
+++ b/android/app/src/main/res/xml/timetable_widget.xml
@@ -4,6 +4,6 @@
     android:minHeight="110dp"
     android:updatePeriodMillis="1800000"
     android:initialLayout="@layout/timetable_layout"
-    android:resizeMode="vertical"
+    android:resizeMode="vertical|horizontal"
     android:widgetCategory="home_screen">
 </appwidget-provider>

--- a/lib/common/widget_data_init.dart
+++ b/lib/common/widget_data_init.dart
@@ -27,6 +27,7 @@ class WidgetDataProvider {
   /// Set weeks info. Has to be set on first start
   static _checkWeeks() async {
     final need = await getIt<WidgetData>().needWeeksReload();
+    print('isNeedWeek $need');
     // if (true) {
     if (need) {
       Map<String, int> days = {};
@@ -48,6 +49,8 @@ class WidgetDataProvider {
   /// Set schedule info on first start
   static _checkSchedule() async {
     // if (true) {
+    print(
+        'isScheduleLoaded ${!(await getIt<WidgetData>().isScheduleLoaded())}');
     if (!(await getIt<WidgetData>().isScheduleLoaded())) {
       try {
         var a = await getIt<ScheduleLocalData>().getScheduleFromCache();

--- a/lib/common/widget_data_init.dart
+++ b/lib/common/widget_data_init.dart
@@ -27,7 +27,7 @@ class WidgetDataProvider {
   /// Set weeks info. Has to be set on first start
   static _checkWeeks() async {
     final need = await getIt<WidgetData>().needWeeksReload();
-    print('isNeedWeek $need');
+    // print('isNeedWeek $need');
     // if (true) {
     if (need) {
       Map<String, int> days = {};
@@ -49,8 +49,8 @@ class WidgetDataProvider {
   /// Set schedule info on first start
   static _checkSchedule() async {
     // if (true) {
-    print(
-        'isScheduleLoaded ${!(await getIt<WidgetData>().isScheduleLoaded())}');
+    // print(
+    //     'isScheduleLoaded ${!(await getIt<WidgetData>().isScheduleLoaded())}');
     if (!(await getIt<WidgetData>().isScheduleLoaded())) {
       try {
         var a = await getIt<ScheduleLocalData>().getScheduleFromCache();


### PR DESCRIPTION
Список предметов не перезагружался при выборе новой группы. Это было вызвано тем, что фабрика списка предметов не обновлялась, т.к. считала интент не уникальным. Теперь он будет уникальным каждый раз, потому что его тип задаётся случайным образом.

```
val adapter = Intent(context, UpdateWidgetService::class.java)
val random = Random()
intent.type = (random.nextInt(2281337)).toString()
```

Демонстрация обновления списка предметов при выборе новой группы:

https://user-images.githubusercontent.com/62698748/145442958-ac173594-eff0-4102-bbbe-d284adb2fc6d.mp4


