### PR TITLE
FIX: Critical calendar error

### DIFF
--- a/android/app/src/main/kotlin/ninja/mirea/mireaapp/HomeWidgerProvider.kt
+++ b/android/app/src/main/kotlin/ninja/mirea/mireaapp/HomeWidgerProvider.kt
@@ -64,7 +64,7 @@ class HomeWidgetProvider : AbstractHomeWidgetProvider() {
 
             val views = RemoteViews(context.packageName, R.layout.timetable_layout).apply {
                 // if semester is going now
-                if (week.toInt() > 0) {
+                if (weekData.matches("\\d+".toRegex()) && week.toInt() > 0) {
                     // set onClick action
                     val pendingIntent = HomeWidgetLaunchIntent.getActivity(
                         context,
@@ -105,7 +105,7 @@ class HomeWidgetProvider : AbstractHomeWidgetProvider() {
             }
 
             // set lessons list
-            if (week.toInt() > 0) {
+            if (weekData.matches("\\d+".toRegex()) && week.toInt() > 0) {
                 setList(views, context, widgetId, scheduleData, week)
             }
 

--- a/lib/common/calendar.dart
+++ b/lib/common/calendar.dart
@@ -15,6 +15,11 @@ abstract class Calendar {
     DateTime currentDate = mCurrentDate ?? clock.now();
     DateTime startDate = getSemesterStart(mCurrentDate: currentDate);
 
+    // If the semester has not begun, return the beginning
+    if (currentDate.isBefore(startDate)) {
+      return 1;
+    }
+
     int week = 1;
     int prevWeekday = startDate.weekday;
 

--- a/lib/presentation/pages/schedule/widgets/schedule_page_view.dart
+++ b/lib/presentation/pages/schedule/widgets/schedule_page_view.dart
@@ -22,12 +22,12 @@ class SchedulePageView extends StatefulWidget {
 }
 
 class _SchedulePageViewState extends State<SchedulePageView> {
+  static final DateTime _firstCalendarDay = Calendar.getSemesterStart();
+  static final DateTime _lastCalendarDay = Calendar.getSemesterLastDay();
+
   late CalendarFormat _calendarFormat;
   late final PageController _controller;
-  final DateTime _firstCalendarDay = Calendar.getSemesterStart();
   DateTime _focusedDay = _validateFocusDay(DateTime.now());
-  final DateTime _lastCalendarDay = Calendar.getSemesterLastDay();
-
   late DateTime _selectedDay;
   late int _selectedPage;
   late int _selectedWeek;
@@ -47,11 +47,12 @@ class _SchedulePageViewState extends State<SchedulePageView> {
             .calendarFormat];
   }
 
-  /// check if current date is before [_lastCalendarDay]
+  /// check if current date is before [_lastCalendarDay] and after [_firstCalendarDay]
   static DateTime _validateFocusDay(DateTime newDate) {
-    final DateTime _lastCalendarDay = Calendar.getSemesterLastDay();
     if (newDate.isAfter(_lastCalendarDay)) {
       return _lastCalendarDay;
+    } else if (newDate.isBefore(_firstCalendarDay)) {
+      return _firstCalendarDay;
     } else {
       return newDate;
     }


### PR DESCRIPTION
Приложение открывалось, зависало и вылетало.

К ошибке приводил код, который пытался получить текущую учебную неделю. Но семестр то ещё не начался, поэтому он бесконечно считал начиная с первого дня следующего семестра до момента переполнения DateTime и вылета приложения.

Что сделано:

- Возврат 1 недели, если семестр ещё не начался
- Дополнительная валидация _focusDate в календаре
- Фикс ошибки виджета, если в weekData находится null