### PR TITLE
FIX: added an emit call after the event handler

### DIFF
--- a/lib/presentation/bloc/schedule_bloc/schedule_bloc.dart
+++ b/lib/presentation/bloc/schedule_bloc/schedule_bloc.dart
@@ -65,7 +65,7 @@ class ScheduleBloc extends Bloc<ScheduleEvent, ScheduleState> {
     // The group for which the schedule is selected
     final activeGroup = await getActiveGroup();
 
-    activeGroup.fold((failure) {
+    await activeGroup.fold((failure) {
       emit(ScheduleActiveGroupEmpty(groups: groupsList));
     }, (activeGroupName) async {
       final schedule = await getSchedule(
@@ -76,7 +76,7 @@ class ScheduleBloc extends Bloc<ScheduleEvent, ScheduleState> {
       // If we have a schedule in the cache then we display it
       // to avoid a long download from the Internet.
       // Otherwise, download the schedule.
-      schedule.fold((failure) async {
+      await schedule.fold((failure) async {
         emit(ScheduleLoading());
         final remoteSchedule = await getSchedule(
             GetScheduleParams(group: activeGroupName, fromRemote: true));


### PR DESCRIPTION
Добавлено ожидания асинхронного вызова `fold` метда для предотвращения ошибки:

```
E/flutter ( 1751): emit was called after an event handler completed normally.
E/flutter ( 1751): This is usually due to an unawaited future in an event handler.
E/flutter ( 1751): Please make sure to await all asynchronous operations with event handlers
E/flutter ( 1751): and use emit.isDone after asynchronous operations before calling emit() to
E/flutter ( 1751): ensure the event handler has not completed.
```