### PR TITLE
UX: hide an empty list of tags in the news

### DIFF
--- a/lib/presentation/pages/news/news_details_page.dart
+++ b/lib/presentation/pages/news/news_details_page.dart
@@ -103,15 +103,19 @@ class _NewsItemInfo extends StatelessWidget {
   Widget build(BuildContext context) {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      mainAxisAlignment: tags.isNotEmpty
+          ? MainAxisAlignment.spaceBetween
+          : MainAxisAlignment.start,
       children: [
-        Expanded(
-          child: Tags(
-            isClickable: false,
-            withIcon: true,
-            tags: tags,
-          ),
-        ),
+        tags.isNotEmpty
+            ? Expanded(
+                child: Tags(
+                  isClickable: false,
+                  withIcon: true,
+                  tags: tags,
+                ),
+              )
+            : Container(),
         Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisAlignment: MainAxisAlignment.end,


### PR DESCRIPTION
#139. В деталях важных новостей пустая иконка тегов больше не отображается