### PR TITLE
UX: fix the bottom indentation on the schedule page

### DIFF
--- a/lib/presentation/pages/schedule/schedule_page.dart
+++ b/lib/presentation/pages/schedule/schedule_page.dart
@@ -333,6 +333,7 @@ class _SchedulePageState extends State<SchedulePage> {
             ],
           ),
           body: SafeArea(
+            bottom: false,
             child: BlocConsumer<ScheduleBloc, ScheduleState>(
               buildWhen: (prevState, currentState) {
                 if (prevState is ScheduleLoaded &&


### PR DESCRIPTION
Убрано ненужное пространство снизу у BottomNavigationBar на странице расписания