### PR TITLE
FIX: delete dialog opening while news loading

### DIFF
--- a/lib/presentation/pages/news/news_page.dart
+++ b/lib/presentation/pages/news/news_page.dart
@@ -101,8 +101,10 @@ class _NewsPageState extends State<NewsPage> {
           ),
           Padding(
             padding: const EdgeInsets.only(right: 12),
-            child:
-                AppSettingsButton(onClick: () => _showTagsModalWindow(context)),
+            child: AppSettingsButton(
+                onClick: () => (context.read<NewsBloc>().state is NewsLoaded)
+                    ? _showTagsModalWindow(context)
+                    : null),
           ),
         ],
       ),


### PR DESCRIPTION
Исправлено #158. Теперь окно тегов не открывается во время загрузки новостей